### PR TITLE
Déplacer les credentials API dans App.config

### DIFF
--- a/MediaTekDocuments/App.config
+++ b/MediaTekDocuments/App.config
@@ -2,6 +2,9 @@
 <configuration>
     <configSections>
     </configSections>
+	<appSettings>
+		<add key="api" value="admin:adminpwd" />
+	</appSettings>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>

--- a/MediaTekDocuments/dal/Access.cs
+++ b/MediaTekDocuments/dal/Access.cs
@@ -63,7 +63,7 @@ namespace MediaTekDocuments.dal
                     .WriteTo.Console()
                     .WriteTo.File("logs/log.txt")
                     .CreateLogger();
-                authenticationString = "admin:adminpwd";
+                authenticationString = ConfigurationManager.AppSettings["api"];
                 api = ApiRest.GetInstance(uriApi, authenticationString);
             }
             catch (Exception e)


### PR DESCRIPTION
Les credentials de l'API étaient en dur dans Access.cs. Ils ont été déplacés dans App.config et récupérés via ConfigurationManager.AppSettings.